### PR TITLE
Remove ORDER_EXECUTION_OPTION_NONE from OrderExecutionOption

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,7 @@
 * Addition of new definitions and support for trade state filters and streaming
 * Refactor DeliveryPeriod to take in a timedelta duration attribute instead of the DeliveryDuration Enum type
 * Public trades renamed from public_trade_lists to public trades and all _lists suffixes removed
+* Remove ORDER_EXECUTION_OPTION_NONE from OrderExecutionOption
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -70,16 +70,15 @@ service ElectricityTradingService {
       returns (stream ReceivePublicTradesStreamResponse);
 }
 
-
-// OrderExecutionOption defines specific behavior for the execution of an order.
-// These options provide control on how an order is handled in the market.
+// OrderExecutionOption defines specific restriction behavior for the execution
+// of an order. These options provide control on how an order is handled in the
+// market.
+// If no OrderExecutionOption is set, the order remains open until it's fully
+// fulfilled, cancelled by the client, `valid_until` timestamp is reached, or
+// the end of the trading session.
 enum OrderExecutionOption {
   // UNSPECIFIED: The order execution option has not been set.
   ORDER_EXECUTION_OPTION_UNSPECIFIED = 0;
-
-  // Order remains open until it's fully fulfilled, cancelled by the client,
-  // `valid_until` timestamp is reached, or the end of the trading session.
-  ORDER_EXECUTION_OPTION_NONE = 1;
 
   // All or None: Order must be executed in its entirety, or not executed at
   // all.
@@ -583,7 +582,7 @@ message UpdateGridpoolOrderRequest {
 
     // Optional; Updated execution options such as All or None,
     // Fill or Kill, etc.
-    OrderExecutionOption execution_option = 7;
+    optional OrderExecutionOption execution_option = 7;
 
     // Optional; This is an updated timestamp defining the time after
     // which the order should be cancelled if not filled.

--- a/py/frequenz/client/electricity_trading/_types.py
+++ b/py/frequenz/client/electricity_trading/_types.py
@@ -427,16 +427,16 @@ class OrderExecutionOption(enum.Enum):
     Specific behavior for the execution of an order.
 
     These options provide control on how an order is handled in the market.
+
+    If no OrderExecutionOption is set, the order remains open until it's fully
+    fulfilled, cancelled by the client, `valid_until` timestamp is reached, or
+    the end of the trading session.
     """
 
     UNSPECIFIED = (
         electricity_trading_pb2.OrderExecutionOption.ORDER_EXECUTION_OPTION_UNSPECIFIED
     )
     """The order execution option has not been set."""
-
-    NONE = electricity_trading_pb2.OrderExecutionOption.ORDER_EXECUTION_OPTION_NONE
-    """Order remains open until it's fully filled, cancelled by the client,
-    `valid_until` timestamp is reached, or the end of the trading session."""
 
     AON = electricity_trading_pb2.OrderExecutionOption.ORDER_EXECUTION_OPTION_AON
     """All or None: Order must be executed in its entirety, or not executed at all."""


### PR DESCRIPTION
We are removing this field to avoid confusions the None variant of optional types, which has the same meaning. Furthermore we make the usage of this enum optional across all messages.
