### PR TITLE
Remove unused `channels` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.5.3, < 0.7.0",
+  "frequenz-api-common >= 0.6.1, < 0.7.0",
   "googleapis-common-protos >= 1.56.4, < 2",
   "grpcio >= 1.60.0, < 2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "frequenz-api-common >= 0.5.3, < 0.7.0",
   "googleapis-common-protos >= 1.56.4, < 2",
   "grpcio >= 1.60.0, < 2",
-  "frequenz-channels >= 0.16.0, < 1.1.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This was preventing the updating of downstream packages to newer
versions of the SDK.