### PR TITLE
Downgrade `frequenz-api-common` version to 0.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.6.1, < 0.7.0",
+  "frequenz-api-common >= 0.5.3, < 0.6.0",
   "googleapis-common-protos >= 1.56.4, < 2",
   "grpcio >= 1.60.0, < 2",
 ]


### PR DESCRIPTION
This is to make this package compatible with current versions of the
SDK.