### PR TITLE
Add explicit enum value for NonRestricted order execution

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,5 @@
 # Frequenz Electricity Trading API Release Notes
 
-## New Features
+## Bug Fixes
 
-- Update repo-config from v0.11.0 to v0.13.0
-- Set `execution_option` field in `PublicOrderRecord` to optional
-- Enhance documentation for `UpdateOrder.OrderExecutionOption` field
-- Add repeated `order_id` filter to `GridpoolOrderFilter`
-- Repeated Order book entries
-- Bump several dependencies
+- Introduce `NON_RESTRICTED` OrderExecutionOption instead of using optional enum field

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -87,6 +87,9 @@ enum OrderExecutionOption {
   // UNSPECIFIED: The order execution option has not been set.
   ORDER_EXECUTION_OPTION_UNSPECIFIED = 0;
 
+  // Not restricted: The order is not restricted.
+  ORDER_EXECUTION_OPTION_NOT_RESTRICTED = 1;
+
   // All or None: Order must be executed in its entirety, or not executed at
   // all.
   ORDER_EXECUTION_OPTION_AON = 2;
@@ -818,7 +821,7 @@ message PublicOrderBookRecord {
   frequenz.api.common.v1.market.Power quantity = 7;
 
   // Execution option (e.g., AON).
-  optional OrderExecutionOption execution_option = 8;
+  OrderExecutionOption execution_option = 8;
 
   // Timestamp when the order was created on the order book.
   google.protobuf.Timestamp create_time = 9;


### PR DESCRIPTION
Previously, we attempted to model the "non-restricted" order execution option by making the `OrderExecutionOption` enum field optional and interpreting `None` (or the absence of the field on the wire) as meaning "non-restricted".

However, setting a Protobuf scalar field like an enum to `None` results in the default value (0) being transmitted on the wire if the field is not explicitly set. Our enum's default value (0) corresponds to `OrderExecutionOption::Unspecified`.

This created an ambiguity: the client received `OrderExecutionOption::Unspecified` whether the server intended "unspecified" or intended "non-restricted" by not setting the optional field. It was impossible for the client to distinguish between these two states.

To resolve this ambiguity and clearly represent the "non-restricted" state, we have added an explicit enum value (e.g., `NON_RESTRICTED` - use the actual name here) to the `OrderExecutionOption` enum.

Clients can now reliably check for this specific enum value to identify the non-restricted option, while `OrderExecutionOption::Unspecified` retains its meaning for genuinely unspecified cases. This aligns with standard Protobuf practices for representing distinct states.
