### PR TITLE
OrderType should be optional for PublicOrderBookRecord

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+- Made `OrderType` optional in `PublicOrderBookRecord` to handle cases where the order type is unknown.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -805,8 +805,11 @@ message PublicOrderBookRecord {
   // Frequenz Delivery period, using the common API type.
   frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 3;
 
-  // The type of order, such as LIMIT, STOP_LIMIT, ICEBERG, etc.
-  OrderType type = 4;
+  // Optional: The type of order (e.g., LIMIT, STOP_LIMIT, ICEBERG).
+  //
+  // If not set, the order type is unknown (for example, if the source market
+  // does not expose the order type).
+  optional OrderType type = 4;
 
   // Indicates if the order was on the Buy or Sell side.
   MarketSide side = 5;


### PR DESCRIPTION
It's not guarenteed that the order type is know for all records in the public order book.
