### PR TITLE
Add delivery_time_filter to filter gridpool orders and trades

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,8 @@
 
 ## Upgrading
 
-- The minimum allowed version of `protobuf` and `grpcio` has been updated to 6.31.1 and 1.72.1 respectively, you might also need to bump your dependencies accordingly.
+- Updates `frequenz-api-common` to v0.7.0 and switch to `v1alpha7` package.
 
 ## New Features
 
-- Made `OrderType` optional in `PublicOrderBookRecord` to handle cases where the order type is unknown.
+- Changes filter for delivery periods for gridpool orders and trades to support filtering by time interval and durations.

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -22,6 +22,7 @@ import "frequenz/api/common/v1alpha7/market/power.proto";
 import "frequenz/api/common/v1alpha7/market/price.proto";
 import "frequenz/api/common/v1alpha7/pagination/pagination_info.proto";
 import "frequenz/api/common/v1alpha7/pagination/pagination_params.proto";
+import "frequenz/api/common/v1alpha7/type/interval.proto";
 
 // Service providing operations related to order management.
 service ElectricityTradingService {
@@ -440,6 +441,64 @@ message PublicTrade {
 
   // Final state of the trade.
   TradeState state = 8;
+}
+
+// Filters delivery periods by start time and duration.
+//
+// A delivery period is defined by a start timestamp and a fixed delivery
+// duration (e.g., 15, 30, or 60 minutes). This filter lets you query for
+// delivery periods that start within an optional time range and optionally
+// match one or more specific durations.
+//
+// The time range is inclusive at the start and exclusive at the end, following
+// the ISO 8601 interval format and conventions in tools like Pandas and Python.
+//
+// !!! tip "Terminology"
+//     - **DeliveryDuration**: A fixed interval (e.g., 15, 30, or 60 minutes).
+//     - **DeliveryPeriod**: A combination of a start time and a
+//       DeliveryDuration.
+//
+// !!! note "Filter Logic"
+//     - `time_interval` is optional; if omitted, all time ranges are matched.
+//     - `duration_filters` is optional; If omitted or empty, all durations will
+//       be included.
+//     - Time range: `start_time` ≤ period_start < `end_time`
+//
+// !!! info "Flexible Duration Filtering"
+//     When `duration_filters` is omitted or empty, the filter will match
+//     delivery periods of all available durations. To restrict results to
+//     specific contract durations, provide one or more `DeliveryDuration`
+//     values.
+//
+// !!! example "Example: All periods on or after a timestamp"
+//     ```json
+//     {
+//       "time_interval": {
+//         "start_time": "2025-06-01T00:00:00Z"
+//       }
+//     }
+//     ```
+//
+// !!! example "Example: Only hourly periods in a range"
+//     ```json
+//     {
+//       "time_interval": {
+//         "start_time": "2025-06-01T00:00:00Z",
+//         "end_time": "2025-06-02T00:00:00Z"
+//       },
+//       "duration_filters": ["DELIVERY_DURATION_60"]
+//     }
+//     ```
+message DeliveryTimeFilter {
+  // Optional; Time window for matching delivery period start times.
+  frequenz.api.common.v1alpha7.type.Interval time_interval = 1;
+
+  // Optional; List of allowed delivery durations.
+  //
+  // If omitted or empty, delivery periods of all supported durations will be
+  // matched.
+  repeated frequenz.api.common.v1alpha7.grid.DeliveryDuration
+      duration_filters = 2;
 }
 
 // Parameters for filtering Gridpool orders.

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -501,13 +501,15 @@ message DeliveryTimeFilter {
       duration_filters = 2;
 }
 
-// Parameters for filtering Gridpool orders.
+// Filters for selecting Gridpool orders.
 //
-// !!! note
-//     Multiple filters can be used in combination to narrow down the returned
-//     results. For example, you can apply both state and side filters
-//     simultaneously to list only the open orders on the buy side of the
-//     market.
+// An order must match all specified criteria to be included in the result.
+//
+// !!! note "Matching Behavior"
+//     - `delivery_time_filter` is optional.
+//     - Filtering over disjoint time intervals requires sending multiple
+//       requests.
+//
 message GridpoolOrderFilter {
   // Optional filter for order state.
   repeated OrderState states = 1;
@@ -515,8 +517,8 @@ message GridpoolOrderFilter {
   // Optional filter for order side.
   optional MarketSide side = 2;
 
-  // Optional filter for delivery period.
-  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 3;
+  // Optional; Filter by delivery period.
+  optional DeliveryTimeFilter delivery_time_filter = 3;
 
   // Optional filter for delivery area.
   frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 4;

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -16,12 +16,12 @@ import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-import "frequenz/api/common/v1/grid/delivery_area.proto";
-import "frequenz/api/common/v1/grid/delivery_duration.proto";
-import "frequenz/api/common/v1/market/power.proto";
-import "frequenz/api/common/v1/market/price.proto";
-import "frequenz/api/common/v1/pagination/pagination_info.proto";
-import "frequenz/api/common/v1/pagination/pagination_params.proto";
+import "frequenz/api/common/v1alpha7/grid/delivery_area.proto";
+import "frequenz/api/common/v1alpha7/grid/delivery_duration.proto";
+import "frequenz/api/common/v1alpha7/market/power.proto";
+import "frequenz/api/common/v1alpha7/market/price.proto";
+import "frequenz/api/common/v1alpha7/pagination/pagination_info.proto";
+import "frequenz/api/common/v1alpha7/pagination/pagination_params.proto";
 
 // Service providing operations related to order management.
 service ElectricityTradingService {
@@ -223,12 +223,12 @@ enum TradeState {
 message Order {
   // The delivery area where the contract is to be delivered. The representation
   // of the delivery area may vary by jurisdiction.
-  frequenz.api.common.v1.grid.DeliveryArea delivery_area = 2;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 2;
 
   // The delivery period for the contract, specified as a start timestamp in UTC
   // and a duration. It represents the period during which the contract is
   // expected to be fulfilled.
-  frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 3;
+  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 3;
 
   // The type of order, such as LIMIT, STOP_LIMIT, ICEBERG etc.
   // This determines how the order is to be executed in the market.
@@ -239,22 +239,22 @@ message Order {
 
   // The limit price at which the contract is to be traded. This is the maximum
   // price for a BUY order or the minimum price for a SELL order.
-  frequenz.api.common.v1.market.Price price = 6;
+  frequenz.api.common.v1alpha7.market.Price price = 6;
 
   // The quantity of the contract being traded, specified in MW.
-  frequenz.api.common.v1.market.Power quantity = 7;
+  frequenz.api.common.v1alpha7.market.Power quantity = 7;
 
   // Optional; Applicable for STOP_LIMIT orders. This is the stop price
   // that triggers the limit order.
-  frequenz.api.common.v1.market.Price stop_price = 8;
+  frequenz.api.common.v1alpha7.market.Price stop_price = 8;
 
   // Optional; Applicable for ICEBERG orders.
   // This is the price difference between the peak price and the limit price.
-  frequenz.api.common.v1.market.Price peak_price_delta = 9;
+  frequenz.api.common.v1alpha7.market.Price peak_price_delta = 9;
 
   // Optional; Applicable for ICEBERG orders. This is the quantity
   // of the order to be displayed in the order book.
-  frequenz.api.common.v1.market.Power display_quantity = 10;
+  frequenz.api.common.v1alpha7.market.Power display_quantity = 10;
 
   // Optional execution options such as All or None, Fill or Kill, etc.
   optional OrderExecutionOption execution_option = 11;
@@ -351,10 +351,10 @@ message OrderDetail {
   StateDetail state_detail = 3;
 
   // Remaining open quantity for this order.
-  frequenz.api.common.v1.market.Power open_quantity = 4;
+  frequenz.api.common.v1alpha7.market.Power open_quantity = 4;
 
   // Filled quantity for this order.
-  frequenz.api.common.v1.market.Power filled_quantity = 5;
+  frequenz.api.common.v1alpha7.market.Power filled_quantity = 5;
 
   // UTC Timestamp when the order was created.
   google.protobuf.Timestamp create_time = 6;
@@ -380,19 +380,19 @@ message Trade {
   MarketSide side = 3;
 
   // Delivery area of the trade.
-  frequenz.api.common.v1.grid.DeliveryArea delivery_area = 4;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 4;
 
   // The delivery period for the contract.
-  frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 5;
+  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 5;
 
   // UTC Timestamp of the trades execution time.
   google.protobuf.Timestamp execution_time = 6;
 
   // The price at which the trade was executed.
-  frequenz.api.common.v1.market.Price price = 7;
+  frequenz.api.common.v1alpha7.market.Price price = 7;
 
   // The executed quantity of the trade.
-  frequenz.api.common.v1.market.Power quantity = 8;
+  frequenz.api.common.v1alpha7.market.Power quantity = 8;
 
   // Current state of the trade.
   TradeState state = 9;
@@ -421,22 +421,22 @@ message PublicTrade {
   uint64 id = 1;
 
   // Delivery area code of the buy side.
-  frequenz.api.common.v1.grid.DeliveryArea buy_delivery_area = 2;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea buy_delivery_area = 2;
 
   // Delivery area code of the sell side.
-  frequenz.api.common.v1.grid.DeliveryArea sell_delivery_area = 3;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea sell_delivery_area = 3;
 
   // The delivery period for the contract.
-  frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 4;
+  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 4;
 
   // UTC Timestamp of the trades execution time.
   google.protobuf.Timestamp execution_time = 5;
 
   // The price at which the trade was executed.
-  frequenz.api.common.v1.market.Price price = 6;
+  frequenz.api.common.v1alpha7.market.Price price = 6;
 
   // The executed quantity of the contract traded.
-  frequenz.api.common.v1.market.Power quantity = 7;
+  frequenz.api.common.v1alpha7.market.Power quantity = 7;
 
   // Final state of the trade.
   TradeState state = 8;
@@ -457,10 +457,10 @@ message GridpoolOrderFilter {
   optional MarketSide side = 2;
 
   // Optional filter for delivery period.
-  frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 3;
+  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 3;
 
   // Optional filter for delivery area.
-  frequenz.api.common.v1.grid.DeliveryArea delivery_area = 4;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 4;
 
   // Optional filters the listed orders by their associated tag.
   optional string tag = 5;
@@ -487,10 +487,10 @@ message GridpoolTradeFilter {
   optional MarketSide side = 3;
 
   // Optional filter for delivery period.
-  frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 4;
+  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 4;
 
   // Optional filter for delivery area.
-  frequenz.api.common.v1.grid.DeliveryArea delivery_area = 5;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 5;
 }
 
 // Parameters for filtering historic public trades.
@@ -509,13 +509,13 @@ message PublicTradeFilter {
   repeated TradeState states = 1;
 
   // Optional; If set, only trades with this delivery period are returned.
-  frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 2;
+  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 2;
 
   // Optional; If set, only trades in this buy delivery area are returned.
-  frequenz.api.common.v1.grid.DeliveryArea buy_delivery_area = 3;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea buy_delivery_area = 3;
 
   // Optional; If set, only trades in this sell delivery area are returned.
-  frequenz.api.common.v1.grid.DeliveryArea sell_delivery_area = 4;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea sell_delivery_area = 4;
 }
 
 // Represents a request to create a new order for a specific Gridpool.
@@ -566,23 +566,23 @@ message UpdateGridpoolOrderRequest {
     // Optional; The updated limit price at which the contract is to be traded.
     // This is the maximum price for a BUY order or the minimum price for a SELL
     // order.
-    frequenz.api.common.v1.market.Price price = 2;
+    frequenz.api.common.v1alpha7.market.Price price = 2;
 
     // Optional; The updated quantity of the contract being traded,
     // specified in MW.
-    frequenz.api.common.v1.market.Power quantity = 3;
+    frequenz.api.common.v1alpha7.market.Power quantity = 3;
 
     // Optional; Applicable for STOP_LIMIT orders. This is the updated
     // stop price that triggers the limit order.
-    frequenz.api.common.v1.market.Price stop_price = 4;
+    frequenz.api.common.v1alpha7.market.Price stop_price = 4;
 
     // Optional; Applicable for ICEBERG orders. This is the updated price
     // difference between the peak price and the limit price.
-    frequenz.api.common.v1.market.Price peak_price_delta = 5;
+    frequenz.api.common.v1alpha7.market.Price peak_price_delta = 5;
 
     // Optional; Applicable for ICEBERG orders. This is the updated quantity
     // of the order to be displayed in the order book.
-    frequenz.api.common.v1.market.Power display_quantity = 6;
+    frequenz.api.common.v1alpha7.market.Power display_quantity = 6;
 
     // Optional; Updated execution options such as All or None,
     // Fill or Kill, etc.
@@ -685,7 +685,8 @@ message ListGridpoolOrdersRequest {
   GridpoolOrderFilter filter = 2;
 
   // Pagination parameters.
-  frequenz.api.common.v1.pagination.PaginationParams pagination_params = 3;
+  frequenz.api.common.v1alpha7.pagination.PaginationParams
+      pagination_params = 3;
 }
 
 // Response from listing orders for a given Gridpool.
@@ -694,7 +695,7 @@ message ListGridpoolOrdersResponse {
   repeated OrderDetail order_details = 1;
 
   // Metadata for pagination, including token for next page to retrieve.
-  frequenz.api.common.v1.pagination.PaginationInfo pagination_info = 2;
+  frequenz.api.common.v1alpha7.pagination.PaginationInfo pagination_info = 2;
 }
 
 // Subscribe to Gridpool order stream.
@@ -729,7 +730,8 @@ message ListGridpoolTradesRequest {
   GridpoolTradeFilter filter = 2;
 
   // Pagination parameters.
-  frequenz.api.common.v1.pagination.PaginationParams pagination_params = 3;
+  frequenz.api.common.v1alpha7.pagination.PaginationParams
+      pagination_params = 3;
 }
 
 // Response from listing trades for a given Gridpool.
@@ -738,7 +740,7 @@ message ListGridpoolTradesResponse {
   repeated Trade trades = 1;
 
   // Metadata for pagination, including token for next page to retrieve.
-  frequenz.api.common.v1.pagination.PaginationInfo pagination_info = 2;
+  frequenz.api.common.v1alpha7.pagination.PaginationInfo pagination_info = 2;
 }
 
 // Subscribe to the stream of gridpool trades.
@@ -800,10 +802,10 @@ message PublicOrderBookRecord {
   uint64 id = 1;
 
   // Frequenz Delivery area, using the common API type.
-  frequenz.api.common.v1.grid.DeliveryArea delivery_area = 2;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 2;
 
   // Frequenz Delivery period, using the common API type.
-  frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 3;
+  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 3;
 
   // Optional: The type of order (e.g., LIMIT, STOP_LIMIT, ICEBERG).
   //
@@ -815,10 +817,10 @@ message PublicOrderBookRecord {
   MarketSide side = 5;
 
   // Order price, using the common API definition for price.
-  frequenz.api.common.v1.market.Price price = 6;
+  frequenz.api.common.v1alpha7.market.Price price = 6;
 
   // Open order quantity, using the common API definition for power.
-  frequenz.api.common.v1.market.Power quantity = 7;
+  frequenz.api.common.v1alpha7.market.Power quantity = 7;
 
   // Execution option (e.g., AON).
   optional OrderExecutionOption execution_option = 8;
@@ -842,11 +844,11 @@ message PublicOrderBookRecord {
 message PublicOrderBookFilter {
   // Optional; if set, only order book entries for this delivery period are
   // returned.
-  frequenz.api.common.v1.grid.DeliveryPeriod delivery_period = 1;
+  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 1;
 
   // Optional; if set, only order book entries for this delivery area are
   // returned.
-  frequenz.api.common.v1.grid.DeliveryArea delivery_area = 2;
+  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 2;
 
   // Optional; if set, only order book entries for this delivery period are
   // returned.

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -528,13 +528,31 @@ message GridpoolOrderFilter {
   repeated uint64 order_ids = 6;
 }
 
-// Parameters for filtering Gridpool trades.
+// Filters for selecting Gridpool trades.
 //
-// !!! note
-//     Multiple filters can be used in combination to narrow down the returned
-//     results. For example, you can apply both state and side filters
-//     simultaneously to list only the trades on the buy side of the
-//     market.
+// A trade must match all specified criteria to be included in the result.
+//
+// !!! note "Matching Behavior"
+//     - `delivery_time_filter` is optional.
+//     - Filtering over disjoint time intervals requires sending multiple
+//       requests.
+//
+// !!! example "Filtering with time interval and trade state"
+//     ```json
+//     {
+//       "states": ["TRADE_STATE_ACTIVE"],
+//       "side": "MARKET_SIDE_SELL",
+//       "delivery_area": "DELIVERY_AREA_DE_50HZ",
+//       "delivery_time_filter": {
+//         "time_interval": {
+//           "start_time": "2025-06-01T00:00:00Z",
+//           "end_time": "2025-06-02T00:00:00Z"
+//         },
+//         "duration_filters": ["DELIVERY_DURATION_60"]
+//       }
+//     }
+//     ```
+//
 message GridpoolTradeFilter {
   // Optional filter for the trade state.
   repeated TradeState states = 1;
@@ -545,8 +563,8 @@ message GridpoolTradeFilter {
   // Optional filter for the trades order side.
   optional MarketSide side = 3;
 
-  // Optional filter for delivery period.
-  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 4;
+  // Optional; Filter by delivery period.
+  optional DeliveryTimeFilter delivery_time_filter = 4;
 
   // Optional filter for delivery area.
   frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 5;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.6.3, < 0.7.0",
+  "frequenz-api-common >= 0.7.0, < 0.8",
   # We can't widen beyond the current value unless we bump the minimum
   # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major


### PR DESCRIPTION
Introduces the `DeliveryTimeFilter` message to support filtering trades or orders by delivery start time and duration. The filter accepts an optional time range and one or more delivery durations, enabling precise querying of delivery periods. The time interval follows inclusive start and exclusive end semantics, consistent with ISO 8601.

The filter requires the (time) `Interval` message from the latest common API, which is updated to v0.7.0 and package `v1alpha7`.

Addresses #142.