### PR TITLE
Update api-common to v0.8.0 and use v1alpha8 package

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Upgrading
 
-- Updates `frequenz-api-common` to v0.7.0 and switch to `v1alpha7` package.
+- Updates `frequenz-api-common` to v0.8.0 and switch to `v1alpha8` package.
 
 ## New Features
 

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -491,7 +491,7 @@ message PublicTrade {
 //     ```
 message DeliveryTimeFilter {
   // Optional; Time window for matching delivery period start times.
-  frequenz.api.common.v1alpha8.type.Interval time_interval = 1;
+  frequenz.api.common.v1alpha8.types.Interval time_interval = 1;
 
   // Optional; List of allowed delivery durations.
   //

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -16,13 +16,13 @@ import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-import "frequenz/api/common/v1alpha7/grid/delivery_area.proto";
-import "frequenz/api/common/v1alpha7/grid/delivery_duration.proto";
-import "frequenz/api/common/v1alpha7/market/power.proto";
-import "frequenz/api/common/v1alpha7/market/price.proto";
-import "frequenz/api/common/v1alpha7/pagination/pagination_info.proto";
-import "frequenz/api/common/v1alpha7/pagination/pagination_params.proto";
-import "frequenz/api/common/v1alpha7/type/interval.proto";
+import "frequenz/api/common/v1alpha8/grid/delivery_area.proto";
+import "frequenz/api/common/v1alpha8/grid/delivery_duration.proto";
+import "frequenz/api/common/v1alpha8/market/power.proto";
+import "frequenz/api/common/v1alpha8/market/price.proto";
+import "frequenz/api/common/v1alpha8/pagination/pagination_info.proto";
+import "frequenz/api/common/v1alpha8/pagination/pagination_params.proto";
+import "frequenz/api/common/v1alpha8/types/interval.proto";
 
 // Service providing operations related to order management.
 service ElectricityTradingService {
@@ -224,12 +224,12 @@ enum TradeState {
 message Order {
   // The delivery area where the contract is to be delivered. The representation
   // of the delivery area may vary by jurisdiction.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 2;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 2;
 
   // The delivery period for the contract, specified as a start timestamp in UTC
   // and a duration. It represents the period during which the contract is
   // expected to be fulfilled.
-  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 3;
+  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 3;
 
   // The type of order, such as LIMIT, STOP_LIMIT, ICEBERG etc.
   // This determines how the order is to be executed in the market.
@@ -240,22 +240,22 @@ message Order {
 
   // The limit price at which the contract is to be traded. This is the maximum
   // price for a BUY order or the minimum price for a SELL order.
-  frequenz.api.common.v1alpha7.market.Price price = 6;
+  frequenz.api.common.v1alpha8.market.Price price = 6;
 
   // The quantity of the contract being traded, specified in MW.
-  frequenz.api.common.v1alpha7.market.Power quantity = 7;
+  frequenz.api.common.v1alpha8.market.Power quantity = 7;
 
   // Optional; Applicable for STOP_LIMIT orders. This is the stop price
   // that triggers the limit order.
-  frequenz.api.common.v1alpha7.market.Price stop_price = 8;
+  frequenz.api.common.v1alpha8.market.Price stop_price = 8;
 
   // Optional; Applicable for ICEBERG orders.
   // This is the price difference between the peak price and the limit price.
-  frequenz.api.common.v1alpha7.market.Price peak_price_delta = 9;
+  frequenz.api.common.v1alpha8.market.Price peak_price_delta = 9;
 
   // Optional; Applicable for ICEBERG orders. This is the quantity
   // of the order to be displayed in the order book.
-  frequenz.api.common.v1alpha7.market.Power display_quantity = 10;
+  frequenz.api.common.v1alpha8.market.Power display_quantity = 10;
 
   // Optional execution options such as All or None, Fill or Kill, etc.
   optional OrderExecutionOption execution_option = 11;
@@ -352,10 +352,10 @@ message OrderDetail {
   StateDetail state_detail = 3;
 
   // Remaining open quantity for this order.
-  frequenz.api.common.v1alpha7.market.Power open_quantity = 4;
+  frequenz.api.common.v1alpha8.market.Power open_quantity = 4;
 
   // Filled quantity for this order.
-  frequenz.api.common.v1alpha7.market.Power filled_quantity = 5;
+  frequenz.api.common.v1alpha8.market.Power filled_quantity = 5;
 
   // UTC Timestamp when the order was created.
   google.protobuf.Timestamp create_time = 6;
@@ -381,19 +381,19 @@ message Trade {
   MarketSide side = 3;
 
   // Delivery area of the trade.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 4;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 4;
 
   // The delivery period for the contract.
-  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 5;
+  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 5;
 
   // UTC Timestamp of the trades execution time.
   google.protobuf.Timestamp execution_time = 6;
 
   // The price at which the trade was executed.
-  frequenz.api.common.v1alpha7.market.Price price = 7;
+  frequenz.api.common.v1alpha8.market.Price price = 7;
 
   // The executed quantity of the trade.
-  frequenz.api.common.v1alpha7.market.Power quantity = 8;
+  frequenz.api.common.v1alpha8.market.Power quantity = 8;
 
   // Current state of the trade.
   TradeState state = 9;
@@ -422,22 +422,22 @@ message PublicTrade {
   uint64 id = 1;
 
   // Delivery area code of the buy side.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea buy_delivery_area = 2;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea buy_delivery_area = 2;
 
   // Delivery area code of the sell side.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea sell_delivery_area = 3;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea sell_delivery_area = 3;
 
   // The delivery period for the contract.
-  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 4;
+  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 4;
 
   // UTC Timestamp of the trades execution time.
   google.protobuf.Timestamp execution_time = 5;
 
   // The price at which the trade was executed.
-  frequenz.api.common.v1alpha7.market.Price price = 6;
+  frequenz.api.common.v1alpha8.market.Price price = 6;
 
   // The executed quantity of the contract traded.
-  frequenz.api.common.v1alpha7.market.Power quantity = 7;
+  frequenz.api.common.v1alpha8.market.Power quantity = 7;
 
   // Final state of the trade.
   TradeState state = 8;
@@ -491,13 +491,13 @@ message PublicTrade {
 //     ```
 message DeliveryTimeFilter {
   // Optional; Time window for matching delivery period start times.
-  frequenz.api.common.v1alpha7.type.Interval time_interval = 1;
+  frequenz.api.common.v1alpha8.type.Interval time_interval = 1;
 
   // Optional; List of allowed delivery durations.
   //
   // If omitted or empty, delivery periods of all supported durations will be
   // matched.
-  repeated frequenz.api.common.v1alpha7.grid.DeliveryDuration
+  repeated frequenz.api.common.v1alpha8.grid.DeliveryDuration
       duration_filters = 2;
 }
 
@@ -521,7 +521,7 @@ message GridpoolOrderFilter {
   optional DeliveryTimeFilter delivery_time_filter = 3;
 
   // Optional filter for delivery area.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 4;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 4;
 
   // Optional filters the listed orders by their associated tag.
   optional string tag = 5;
@@ -569,7 +569,7 @@ message GridpoolTradeFilter {
   optional DeliveryTimeFilter delivery_time_filter = 4;
 
   // Optional filter for delivery area.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 5;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 5;
 }
 
 // Parameters for filtering historic public trades.
@@ -588,13 +588,13 @@ message PublicTradeFilter {
   repeated TradeState states = 1;
 
   // Optional; If set, only trades with this delivery period are returned.
-  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 2;
+  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 2;
 
   // Optional; If set, only trades in this buy delivery area are returned.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea buy_delivery_area = 3;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea buy_delivery_area = 3;
 
   // Optional; If set, only trades in this sell delivery area are returned.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea sell_delivery_area = 4;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea sell_delivery_area = 4;
 }
 
 // Represents a request to create a new order for a specific Gridpool.
@@ -645,23 +645,23 @@ message UpdateGridpoolOrderRequest {
     // Optional; The updated limit price at which the contract is to be traded.
     // This is the maximum price for a BUY order or the minimum price for a SELL
     // order.
-    frequenz.api.common.v1alpha7.market.Price price = 2;
+    frequenz.api.common.v1alpha8.market.Price price = 2;
 
     // Optional; The updated quantity of the contract being traded,
     // specified in MW.
-    frequenz.api.common.v1alpha7.market.Power quantity = 3;
+    frequenz.api.common.v1alpha8.market.Power quantity = 3;
 
     // Optional; Applicable for STOP_LIMIT orders. This is the updated
     // stop price that triggers the limit order.
-    frequenz.api.common.v1alpha7.market.Price stop_price = 4;
+    frequenz.api.common.v1alpha8.market.Price stop_price = 4;
 
     // Optional; Applicable for ICEBERG orders. This is the updated price
     // difference between the peak price and the limit price.
-    frequenz.api.common.v1alpha7.market.Price peak_price_delta = 5;
+    frequenz.api.common.v1alpha8.market.Price peak_price_delta = 5;
 
     // Optional; Applicable for ICEBERG orders. This is the updated quantity
     // of the order to be displayed in the order book.
-    frequenz.api.common.v1alpha7.market.Power display_quantity = 6;
+    frequenz.api.common.v1alpha8.market.Power display_quantity = 6;
 
     // Optional; Updated execution options such as All or None,
     // Fill or Kill, etc.
@@ -764,7 +764,7 @@ message ListGridpoolOrdersRequest {
   GridpoolOrderFilter filter = 2;
 
   // Pagination parameters.
-  frequenz.api.common.v1alpha7.pagination.PaginationParams
+  frequenz.api.common.v1alpha8.pagination.PaginationParams
       pagination_params = 3;
 }
 
@@ -774,7 +774,7 @@ message ListGridpoolOrdersResponse {
   repeated OrderDetail order_details = 1;
 
   // Metadata for pagination, including token for next page to retrieve.
-  frequenz.api.common.v1alpha7.pagination.PaginationInfo pagination_info = 2;
+  frequenz.api.common.v1alpha8.pagination.PaginationInfo pagination_info = 2;
 }
 
 // Subscribe to Gridpool order stream.
@@ -809,7 +809,7 @@ message ListGridpoolTradesRequest {
   GridpoolTradeFilter filter = 2;
 
   // Pagination parameters.
-  frequenz.api.common.v1alpha7.pagination.PaginationParams
+  frequenz.api.common.v1alpha8.pagination.PaginationParams
       pagination_params = 3;
 }
 
@@ -819,7 +819,7 @@ message ListGridpoolTradesResponse {
   repeated Trade trades = 1;
 
   // Metadata for pagination, including token for next page to retrieve.
-  frequenz.api.common.v1alpha7.pagination.PaginationInfo pagination_info = 2;
+  frequenz.api.common.v1alpha8.pagination.PaginationInfo pagination_info = 2;
 }
 
 // Subscribe to the stream of gridpool trades.
@@ -881,10 +881,10 @@ message PublicOrderBookRecord {
   uint64 id = 1;
 
   // Frequenz Delivery area, using the common API type.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 2;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 2;
 
   // Frequenz Delivery period, using the common API type.
-  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 3;
+  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 3;
 
   // Optional: The type of order (e.g., LIMIT, STOP_LIMIT, ICEBERG).
   //
@@ -896,10 +896,10 @@ message PublicOrderBookRecord {
   MarketSide side = 5;
 
   // Order price, using the common API definition for price.
-  frequenz.api.common.v1alpha7.market.Price price = 6;
+  frequenz.api.common.v1alpha8.market.Price price = 6;
 
   // Open order quantity, using the common API definition for power.
-  frequenz.api.common.v1alpha7.market.Power quantity = 7;
+  frequenz.api.common.v1alpha8.market.Power quantity = 7;
 
   // Execution option (e.g., AON).
   optional OrderExecutionOption execution_option = 8;
@@ -923,11 +923,11 @@ message PublicOrderBookRecord {
 message PublicOrderBookFilter {
   // Optional; if set, only order book entries for this delivery period are
   // returned.
-  frequenz.api.common.v1alpha7.grid.DeliveryPeriod delivery_period = 1;
+  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 1;
 
   // Optional; if set, only order book entries for this delivery area are
   // returned.
-  frequenz.api.common.v1alpha7.grid.DeliveryArea delivery_area = 2;
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 2;
 
   // Optional; if set, only order book entries for this delivery period are
   // returned.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.7.0, < 0.8",
+  "frequenz-api-common >= 0.8.0, < 0.9",
   # We can't widen beyond the current value unless we bump the minimum
   # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major


### PR DESCRIPTION
This fixes keyword issues with the `type` package in rust.