### PR TITLE
Relax dependency on frequenz-api-common to support up to v1.0.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,5 @@
 # Frequenz Electricity Trading API Release Notes
 
-## Upgrading
+## Summary
 
-- Updates `frequenz-api-common` to v0.8.0 and switch to `v1alpha8` package.
-
-## New Features
-
-- Changes filter for delivery periods for gridpool orders and trades to support filtering by time interval and durations.
+This version relaxes the dependency on `frequenz-api-common` to support up to version 1.0.0, as this repository now guarantees backwards compatibility between v0.x releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,15 @@ name = "frequenz-api-electricity-trading"
 description = "Specification for Electricity Trading API."
 readme = "README.md"
 license = { text = "MIT" }
-keywords = ["frequenz", "python", "api", "grpc", "protobuf", "rpc", "electricity-trading"]
+keywords = [
+  "frequenz",
+  "python",
+  "api",
+  "grpc",
+  "protobuf",
+  "rpc",
+  "electricity-trading",
+]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
@@ -33,7 +41,7 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.8.0, < 0.9",
+  "frequenz-api-common >= 0.8.0, < 1",
   # We can't widen beyond the current value unless we bump the minimum
   # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
@@ -53,7 +61,7 @@ email = "floss@frequenz.com"
 dev-flake8 = [
   "flake8 == 7.2.0",
   "flake8-docstrings == 1.7.0",
-  "flake8-pyproject == 1.2.3",  # For reading the flake8 config from pyproject.toml
+  "flake8-pyproject == 1.2.3", # For reading the flake8 config from pyproject.toml
   "pydoclint == 0.6.6",
   "pydocstyle == 6.3.0",
 ]
@@ -76,10 +84,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-electricity-trading[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-noxfile = [
-  "nox == 2025.5.1",
-  "frequenz-repo-config[api] == 0.13.5",
-]
+dev-noxfile = ["nox == 2025.5.1", "frequenz-repo-config[api] == 0.13.5"]
 dev-pylint = [
   "pylint == 3.3.7",
   # For checking the noxfile, docs/ script, and tests


### PR DESCRIPTION
This PR relaxes the dependency on `frequenz-api-common` to support up to version 1.0.0, as this repository now guarantees backwards compatibility between v0.x releases.
