### PR TITLE
Add tag option to GridpoolTradeFilter

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,7 @@
 ## Summary
 
 This version relaxes the dependency on `frequenz-api-common` to support up to version 1.0.0, as this repository now guarantees backwards compatibility between v0.x releases.
+
+## New Features
+
+* Add tag option to GridpoolTradeFilter.

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -570,6 +570,9 @@ message GridpoolTradeFilter {
 
   // Optional filter for delivery area.
   frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 5;
+
+  // Optionally filters trades by their associated tag.
+  optional string tag = 6;
 }
 
 // Parameters for filtering historic public trades.


### PR DESCRIPTION
This allows to filter gridpool trades by the tag that was used with its associated order.