### PR TITLE
Docs: clarify public trades and order book streaming semantics as well as examples

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-* Update all Delivery Period examples in the docs to 15 minutes
+* Electricity Trading: improved documentation for public trades and order book streams (time filtering semantics, reconnect expectations, and examples).
 
 ## Bug Fixes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,22 +95,12 @@ plugins:
   - mike:
       alias_type: redirect
       canonical_version: latest
-
   - mkdocstrings:
       default_handler: python
       handlers:
         python:
           options:
-            extra:
-              paths: ["py"]
-
-            # Avoid strict-mode failure from generated grpc/protobuf code
-            # (prevents griffe warnings like "No type or annotation for
-            # parameter 'channel'")
-            filters:
-              - "!.*_pb2$"
-              - "!.*_pb2_grpc$"
-
+            paths: ["py"]
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false
@@ -121,14 +111,12 @@ plugins:
             show_signature_annotations: true
             show_source: true
             signature_crossrefs: true
-
-          inventories:
+          import:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
             - https://frequenz-floss.github.io/frequenz-api-common/v0.3/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
-
   # Note this plugin must be loaded after mkdocstrings to be able to use macros
   # inside docstrings.
   - macros:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,12 +95,22 @@ plugins:
   - mike:
       alias_type: redirect
       canonical_version: latest
+
   - mkdocstrings:
       default_handler: python
       handlers:
         python:
           options:
-            paths: ["py"]
+            extra:
+              paths: ["py"]
+
+            # Avoid strict-mode failure from generated grpc/protobuf code
+            # (prevents griffe warnings like "No type or annotation for
+            # parameter 'channel'")
+            filters:
+              - "!.*_pb2$"
+              - "!.*_pb2_grpc$"
+
             docstring_section_style: spacy
             inherited_members: true
             merge_init_into_class: false
@@ -111,12 +121,14 @@ plugins:
             show_signature_annotations: true
             show_source: true
             signature_crossrefs: true
-          import:
+
+          inventories:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
             - https://frequenz-floss.github.io/frequenz-api-common/v0.3/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
+
   # Note this plugin must be loaded after mkdocstrings to be able to use macros
   # inside docstrings.
   - macros:

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -797,6 +797,7 @@ message GridpoolTradeFilter {
 //     results. For example, you can apply both state and delivery area filters
 //     simultaneously to list only the trades that occurred at a certain time in
 //     a specific delivery area.
+//
 message PublicTradeFilter {
   // If set, only trades in this state are returned.
   repeated TradeState states = 1;
@@ -856,7 +857,7 @@ message CreateGridpoolOrderRequest {
   Order order = 2;
 }
 
-// Represents the server's response after a new order has been successfully
+// Represents the service's response after a new order has been successfully
 // created for a specific Gridpool.
 //
 // This response provides essential details about the newly created order, such
@@ -1014,23 +1015,35 @@ message ListGridpoolOrdersResponse {
 
 // Request message for subscribing to the stream of Gridpool order updates.
 //
-// This request selects the Gridpool whose order updates are streamed and
-// optionally restricts which orders are included in the stream.
+// This request identifies the Gridpool whose order updates are streamed and
+// optionally restricts which orders are included using `filter`. Order updates
+// are emitted as they are observed by the service and match the request filter.
 //
 // !!! note "Stream Lifetime"
-//     The lifetime of the stream depends on whether an upper delivery-time
-//     bound is specified:
+//     Stream termination is best-effort. The service may close the stream
+//     once it determines that no further order updates are expected to match
+//     the request filter (for example, when a bounded delivery-time window
+//     has been fully exhausted).
 //
-//     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
-//       in the past, no entries are returned and the stream is closed
-//       immediately.
-//     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
-//       in the future, the server may close the stream once no further orders
-//       can match the filter (typically shortly after `end_time`).
-//     - If no `end_time` is specified, the stream remains open and continues
-//       emitting matching trade updates until closed by the client or server.
+//     - If `filter.delivery_time_filter.time_interval.end_time` lies in the
+//       past relative to the connection time, the service may return no
+//       entries and close the stream immediately, as no further matching
+//       order updates are expected (best-effort).
+//     - If `filter.delivery_time_filter.time_interval.end_time` lies in the
+//       future, the service may close the stream once the bound has passed and
+//       the filter is exhausted (typically shortly after `end_time`).
+//     - If no upper delivery-time bound is specified, the stream may remain
+//       open and continues emitting matching order updates until closed by
+//       the client or service.
+//
+//     Streams reflect order updates as they are observed by the service.
+//     Late-arriving updates for delivery periods in the past may still be
+//     emitted if they are observed before the stream is closed.
 //
 // !!! example "Example: Stream all future orders (no end bound)"
+//     Streams order updates for all delivery periods whose delivery start
+//     time is greater than or equal to `2026-01-07T00:00:00Z`.
+//
 //     ```json
 //     {
 //       "gridpool_id": 1,
@@ -1043,6 +1056,11 @@ message ListGridpoolOrdersResponse {
 //     ```
 //
 // !!! example "Example: Stream orders for a delivery window"
+//     This example streams order updates for all delivery periods whose
+//     delivery start time falls within the specified time interval.
+//     The filter does not select a single delivery period, but a set of
+//     delivery periods matched by their start time.
+//
 //     ```json
 //     {
 //       "gridpool_id": 1,
@@ -1102,25 +1120,32 @@ message ListGridpoolTradesResponse {
 // This request identifies the Gridpool whose trades are streamed and optionally
 // restricts which trades are included using `filter`.
 //
-// !!! note "Filtering"
-//     When `filter.delivery_time_filter` is set, it restricts trades based on
-//     the start time of their `delivery_period`. See `DeliveryTimeFilter` for
-//     detailed matching semantics.
-//
 // !!! note "Stream Lifetime"
-//     The lifetime of the stream depends on whether an upper delivery-time
-//     bound is specified:
+//     Stream termination is best-effort. The service may close the stream once
+//     it determines that no further trade updates are expected to match the
+//     request filter (for example, when a bounded delivery-time window has
+//     been fully exhausted).
 //
-//     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
-//       in the past, no entries are returned and the stream is closed
-//       immediately.
-//     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
-//       in the future, the server may close the stream once no further trades
-//       can match the filter (typically shortly after `end_time`).
-//     - If no `end_time` is specified, the stream remains open and continues
-//       emitting matching trade updates until closed by the client or server.
+//     - If `filter.delivery_time_filter.time_interval.end_time` lies in the
+//       past relative to the connection time, the service may return no
+//       entries and close the stream immediately, as no further matching
+//       trades are expected (best-effort).
+//     - If `filter.delivery_time_filter.time_interval.end_time` lies in the
+//       future, the service may close the stream once the bound has passed and
+//       the filter is exhausted (typically shortly after `end_time`).
+//     - If no upper delivery-time bound is specified, the stream may remain
+//       open and continues emitting matching trade updates until closed by
+//       the client or service.
+//
+//     Streams reflect trades as they are observed by the service. Late-arriving
+//     records for delivery periods in the past may still be emitted if they are
+//     observed before the stream is closed.
 //
 // !!! example "Example: Stream all trades for the next hour"
+//     Streams trades for all delivery periods whose delivery start time
+//     falls within the specified time interval.
+//     The filter matches a set of delivery periods, not a single contract.
+//
 //     ```json
 //     {
 //       "gridpool_id": 1,
@@ -1181,23 +1206,24 @@ message ReceiveGridpoolTradesStreamResponse {
 // the replay window (`start_time` / `end_time`) and the attribute constraints
 // in `filter`.
 //
-// !!! note "Time Domains"
-//     This request uses two different time concepts:
-//     - `start_time` / `end_time` filter by trade execution time
-//       (`PublicTrade.execution_time`).
-//     - `filter.delivery_period` filters by the delivery period of the traded
-//       contract (`PublicTrade.delivery_period`), i.e., which product was
-//       traded.
-//
 // !!! note "Replay Window Semantics"
-//     The replay window is a half-open interval on execution time:
+//     The replay window is a half-open interval on trade execution time
+//     (`PublicTrade.execution_time`):
+//
 //     `start_time` ≤ execution_time < `end_time`.
+//
 //     - If `start_time` is omitted, only trades observed after the connection
 //       is established are emitted.
-//     - If `end_time` is omitted, the stream remains open and continues
-//       emitting new trades.
-//     - If `end_time` is set and is in the past, the server returns no entries
-//       and closes the stream immediately.
+//     - If `end_time` is omitted, the stream may remain open and continues
+//       emitting new trades until closed by the client or service.
+//     - If `end_time` is set and lies in the past, the service returns no
+//       entries and closes the stream immediately.
+//
+//     Stream termination is best-effort. The service may close the stream once
+//     it determines that no further trades can match the request (for example,
+//     when the replay window is bounded and exhausted, or when `filter` selects
+//     a delivery period that is already in the past and no further trades are
+//     expected).
 //
 // !!! example "Example: Stream live trades for 60-min delivery periods"
 //     The following request streams all future public trades for the specified
@@ -1214,8 +1240,8 @@ message ReceiveGridpoolTradesStreamResponse {
 //     }
 //     ```
 //
-//     Since `end_time` is omitted, the stream remains open until closed by
-//     the server or the client.
+//     Since `start_time` and `end_time` (replay window) are omitted, the
+//     stream remains open until closed by the service or the client.
 //
 message ReceivePublicTradesStreamRequest {
   // Optional filter to specify which trades should be included in the stream.
@@ -1271,18 +1297,18 @@ message ReceivePublicTradesStreamResponse {
 //
 //     `start_time` ≤ update_time < `end_time`
 //
-//     - If `start_time` is omitted, only updates observed after the connection
-//       is established are emitted.
-//     - If `end_time` is omitted, the stream remains open and continues
-//       emitting new updates.
+//     - If `start_time` is omitted, only order book updates observed after the
+//       connection is established are emitted.
+//     - If `end_time` is omitted, the stream may remain open and continues
+//       emitting new order book updates until closed by the client or service.
 //     - If `end_time` is set, it must refer to a timestamp in the past. If it
-//       lies in the past relative to the connection time, the server returns no
-//       entries and closes the stream immediately.
+//       lies in the past relative to the connection time, the service returns
+//       no entries and closes the stream immediately.
 //
-// !!! note "Filtering"
-//     The optional `filter` restricts which order book records are emitted
-//     (e.g., by delivery period, delivery area, or market side). Filtering is
-//     applied in addition to the replay window.
+//     Stream termination is best-effort. The service may close the stream once
+//     it determines that no further records can match the request (for example,
+//     when `filter` selects a delivery period that is already in the past and
+//     no further updates are expected).
 //
 message ReceivePublicOrderBookStreamRequest {
   // Optional filter to narrow down the public order book entries returned.

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -1025,7 +1025,7 @@ message ListGridpoolOrdersResponse {
 //       in the past, no entries are returned and the stream is closed
 //       immediately.
 //     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
-//       in the future, the server may close the stream once no further trades
+//       in the future, the server may close the stream once no further orders
 //       can match the filter (typically shortly after `end_time`).
 //     - If no `end_time` is specified, the stream remains open and continues
 //       emitting matching trade updates until closed by the client or server.

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -182,6 +182,10 @@ import "frequenz/api/common/v1alpha8/types/interval.proto";
 //     This sequence represents a suggested operational flow for automated
 //     trading, position management, and portfolio optimisation.
 //
+// !!! note "Stream Termination & Reconnect"
+//     The service may terminate long-lived streams for operational reasons.
+//     Clients should treat streams as best-effort and be prepared to reconnect.
+//
 // !!! important "Authentication"
 //     All requests to ElectricityTradingService must be signed. The key
 //     identifier and signature must be included in the request metadata
@@ -227,13 +231,6 @@ service ElectricityTradingService {
       returns (stream ReceiveGridpoolTradesStreamResponse);
 
   // This stream provides both historical and real-time public trade data.
-  //
-  // - If `start_time` is set, it retrieves trades from that timestamp onwards.
-  //   If omitted, it streams only new trades from the time the connection is
-  //   established.
-  // - If `end_time` is set, the stream stops after sending trades up to this
-  //   timestamp.
-  //   If omitted, it remains open and continues streaming new trades.
   rpc ReceivePublicTradesStream(ReceivePublicTradesStreamRequest)
       returns (stream ReceivePublicTradesStreamResponse);
 
@@ -663,18 +660,21 @@ message PublicOrderBookRecord {
 // The time range is inclusive at the start and exclusive at the end, following
 // the ISO 8601 interval format and conventions in tools like Pandas and Python.
 //
-// !!! tip "Terminology"
-//     - **DeliveryDuration**: A fixed interval (e.g., 15, 30, or 60 minutes).
-//     - **DeliveryPeriod**: A combination of a start time and a
+// !!! note "Terminology"
+//     - DeliveryDuration: A fixed interval (e.g., 15, 30, or 60 minutes).
+//     - DeliveryPeriod: A combination of a start time and a
 //       DeliveryDuration.
 //
-// !!! note "Filter Logic"
-//     - `time_interval` is optional; if omitted, all time ranges are matched.
-//     - `duration_filters` is optional; If omitted or empty, all durations will
-//       be included.
-//     - Time range: `start_time` ≤ period_start < `end_time`
+// !!! note "Matching Semantics"
+//     - Delivery periods are matched by their start time using a half-open
+//       interval: `start_time` ≤ period_start < `end_time`.
+//     - If `time_interval.start_time` is omitted, the interval is unbounded at
+//       the start.
+//     - If `time_interval.end_time` is omitted, the interval is unbounded at
+//       the end.
+//     - If `time_interval` is omitted entirely, all start times are matched.
 //
-// !!! info "Flexible Duration Filtering"
+// !!! note "Flexible Duration Filtering"
 //     When `duration_filters` is omitted or empty, the filter will match
 //     delivery periods of all available durations. To restrict results to
 //     specific contract durations, provide one or more `DeliveryDuration`
@@ -728,6 +728,7 @@ message GridpoolOrderFilter {
   optional MarketSide side = 2;
 
   // Optional; Filter by delivery period.
+  // See `DeliveryTimeFilter` for matching semantics.
   optional DeliveryTimeFilter delivery_time_filter = 3;
 
   // Optional filter for delivery area.
@@ -749,7 +750,7 @@ message GridpoolOrderFilter {
 //     - Filtering over disjoint time intervals requires sending multiple
 //       requests.
 //
-// !!! example "Filtering with time interval and trade state"
+// !!! example "Example: Filtering with time interval and trade state"
 //     ```json
 //     {
 //       "states": ["TRADE_STATE_ACTIVE"],
@@ -776,6 +777,7 @@ message GridpoolTradeFilter {
   optional MarketSide side = 3;
 
   // Optional; Filter by delivery period.
+  // See `DeliveryTimeFilter` for matching semantics.
   optional DeliveryTimeFilter delivery_time_filter = 4;
 
   // Optional filter for delivery area.
@@ -1011,35 +1013,23 @@ message ListGridpoolOrdersResponse {
   frequenz.api.common.v1alpha8.pagination.PaginationInfo pagination_info = 2;
 }
 
-// Subscribe to the stream of Gridpool order updates.
+// Request message for subscribing to the stream of Gridpool order updates.
 //
-// This RPC streams order updates for the given Gridpool and optionally filters
-// the streamed orders.
-//
-// !!! note "Filter Semantics"
-//     The `delivery_time_filter` matches orders by their `delivery_period
-//     .start_time` using a half-open time interval:
-//
-//     - Time range: `start_time` ≤ period_start < `end_time`
-//     - If `start_time` is omitted, the interval is unbounded at the start.
-//     - If `end_time` is omitted, the interval is unbounded at the end.
-//     - If `delivery_time_filter` is omitted, no delivery-time filtering is
-//        applied.
+// This request selects the Gridpool whose order updates are streamed and
+// optionally restricts which orders are included in the stream.
 //
 // !!! note "Stream Lifetime"
-//     The stream starts immediately.
-//     - If `end_time` is set and is in the future, the server may close the
-//       stream once no further orders can match the filter (typically
-//       shortly after `end_time`).
-//     - If `end_time` is set and is in the past, the server returns no
-//       entries and closes the stream immediately.
-//     - If `end_time` is omitted, the stream remains open and continues
-//       emitting matching order updates until the client closes it.
+//     The lifetime of the stream depends on whether an upper delivery-time
+//     bound is specified:
 //
-// !!! note "Stream Termination & Reconnect"
-//     The server may terminate long-lived streams for operational reasons.
-//     Clients should treat streams as best-effort and be prepared to reconnect,
-//     resuming from the last observed `execution_time` if needed.
+//     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
+//       in the past, no entries are returned and the stream is closed
+//       immediately.
+//     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
+//       in the future, the server may close the stream once no further trades
+//       can match the filter (typically shortly after `end_time`).
+//     - If no `end_time` is specified, the stream remains open and continues
+//       emitting matching trade updates until closed by the client or server.
 //
 // !!! example "Example: Stream all future orders (no end bound)"
 //     ```json
@@ -1076,8 +1066,11 @@ message ReceiveGridpoolOrdersStreamRequest {
   GridpoolOrderFilter filter = 2;
 }
 
-// Response to a subscription request for a stream of Gridpool orders.
-// Real-time information on gridpool orders is pushed through this response.
+// Streamed Gridpool order update response.
+//
+// Each message contains the latest known `OrderDetail` for an order that
+// matches the request filter.
+//
 message ReceiveGridpoolOrdersStreamResponse {
   // Order detail response.
   OrderDetail order_detail = 1;
@@ -1105,35 +1098,28 @@ message ListGridpoolTradesResponse {
   frequenz.api.common.v1alpha8.pagination.PaginationInfo pagination_info = 2;
 }
 
-// Subscribe to the stream of Gridpool trades.
+// Request message for subscribing to the stream of Gridpool trade updates.
 //
-// This RPC streams newly observed trades for the given Gridpool and optionally
-// filters them.
+// This request identifies the Gridpool whose trades are streamed and optionally
+// restricts which trades are included using `filter`.
 //
-// !!! note "Filter Semantics"
-//     The `delivery_time_filter` matches trades by their `delivery_period
-//     .start_time` using a half-open time interval:
-//
-//     - Time range: `start_time` ≤ period_start < `end_time`
-//     - If `start_time` is omitted, the interval is unbounded at the start.
-//     - If `end_time` is omitted, the interval is unbounded at the end.
-//     - If `delivery_time_filter` is omitted, no delivery-time filtering is
-//       applied.
+// !!! note "Filtering"
+//     When `filter.delivery_time_filter` is set, it restricts trades based on
+//     the start time of their `delivery_period`. See `DeliveryTimeFilter` for
+//     detailed matching semantics.
 //
 // !!! note "Stream Lifetime"
-//     The stream starts immediately.
-//     - If `end_time` is set and is in the past, the server returns no entries
-//       and closes the stream immediately.
-//     - If `end_time` is omitted, the stream remains open and emits matching
-//       trades until the client closes it.
-//     - If `end_time` is set and is in the future, the server may close the
-//       stream once no further trades can match the filter (typically
-//       shortly after `end_time`).
+//     The lifetime of the stream depends on whether an upper delivery-time
+//     bound is specified:
 //
-// !!! note "Stream Termination & Reconnect"
-//     The server may terminate long-lived streams for operational reasons.
-//     Clients should treat streams as best-effort and be prepared to reconnect,
-//     resuming from the last observed `execution_time` if needed.
+//     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
+//       in the past, no entries are returned and the stream is closed
+//       immediately.
+//     - If `filter.delivery_time_filter.time_interval.end_time` is set and lies
+//       in the future, the server may close the stream once no further trades
+//       can match the filter (typically shortly after `end_time`).
+//     - If no `end_time` is specified, the stream remains open and continues
+//       emitting matching trade updates until closed by the client or server.
 //
 // !!! example "Example: Stream all trades for the next hour"
 //     ```json
@@ -1159,21 +1145,42 @@ message ReceiveGridpoolTradesStreamRequest {
 }
 
 // Response to a subscription request for a stream of Gridpool trades.
-// Real-time information on trades is pushed through this response.
+//
+// Each response message contains a single `Trade` that matches the request
+// parameters. Trades may be emitted as part of historical replay or as newly
+// observed trades.
+//
+// !!! example "Example: Gridpool trade response"
+//     ```json
+//     {
+//       "trade": {
+//         "id": "5001",
+//         "order_id": "12345",
+//         "side": "MARKET_SIDE_BUY",
+//         "delivery_area": "DELIVERY_AREA_DE_LU",
+//         "delivery_period": {
+//           "start_time": "2026-01-07T12:00:00Z",
+//           "duration": "DELIVERY_DURATION_60"
+//         },
+//         "execution_time": "2026-01-07T11:59:50Z",
+//         "price": { "currency": "EUR", "amount": "85.50" },
+//         "quantity": { "mw": "1.0" },
+//         "state": "TRADE_STATE_ACTIVE"
+//       }
+//     }
+//     ```
+//
 message ReceiveGridpoolTradesStreamResponse {
-  // The trade that has been executed and is being broadcasted in
-  // real-time.
+  // Trade belonging to the Gridpool that matches the request filter.
   Trade trade = 1;
 }
 
-// Subscribe to the stream of public trades.
+// Request message to subscribe to the stream of public trades.
 //
-// This stream supports both historical replay and real-time updates.
-// Trades are included only if they match both:
-//
-//   1) the replay window defined by `start_time` / `end_time` (execution time),
-//   2) the `filter` constraints (trade attributes such as delivery period,
-//      area and/or state.
+// This request optionally replays historical public trades and can remain open
+// to stream newly observed trades. Trades are emitted only if they match both
+// the replay window (`start_time` / `end_time`) and the attribute constraints
+// in `filter`.
 //
 // !!! note "Time Domains"
 //     This request uses two different time concepts:
@@ -1186,19 +1193,14 @@ message ReceiveGridpoolTradesStreamResponse {
 // !!! note "Replay Window Semantics"
 //     The replay window is a half-open interval on execution time:
 //     `start_time` ≤ execution_time < `end_time`.
-//     - If `start_time` is omitted, the stream emits only new trades observed
-//       after the connection is established.
+//     - If `start_time` is omitted, only trades observed after the connection
+//       is established are emitted.
 //     - If `end_time` is omitted, the stream remains open and continues
 //       emitting new trades.
 //     - If `end_time` is set and is in the past, the server returns no entries
 //       and closes the stream immediately.
 //
-// !!! note "Stream Termination & Reconnect"
-//     The server may terminate long-lived streams for operational reasons.
-//     Clients should treat streams as best-effort and be prepared to reconnect,
-//     resuming from the last observed `execution_time` if needed.
-//
-// !!! example "Example: Stream live trades for a delivery period"
+// !!! example "Example: Stream live trades for 60-min delivery periods"
 //     The following request streams all future public trades for the specified
 //     delivery period as they occur:
 //
@@ -1213,36 +1215,56 @@ message ReceiveGridpoolTradesStreamResponse {
 //     }
 //     ```
 //
-//     Since `start_time` and `end_time` are omitted, the stream emits only new
-//     trades observed after the connection is established and remains open
-//     until closed by the server or the client.
+//     Since `end_time` is omitted, the stream remains open until closed by
+//     the server or the client.
 //
 message ReceivePublicTradesStreamRequest {
   // Optional filter to specify which trades should be included in the stream.
   PublicTradeFilter filter = 1;
 
-  // Optional; if set, retrieves trades executed at or after this timestamp.
-  // If omitted, streams only new trades from the time of connection.
+  // Optional; start of the replay window for trade execution time (inclusive).
+  // If omitted, only new trades observed after the connection is established
+  // are emitted.
   google.protobuf.Timestamp start_time = 2;
 
-  // Optional; if set, the stream stops after sending trades up to this
-  // timestamp.
-  // If omitted, the stream continues to stream new trades as they occur.
+  // Optional; end of the replay window for trade execution time (exclusive).
+  // If omitted, the stream remains open and continues emitting new trades.
   google.protobuf.Timestamp end_time = 3;
 }
 
 // Response to a subscription request for a stream of public trades.
-// Real-time information on public trades is pushed through this response.
+//
+// !!! example "Example: Public trade response"
+//     ```json
+//     {
+//       "public_trade": {
+//         "id": "9001",
+//         "buy_delivery_area": "DELIVERY_AREA_DE_LU",
+//         "sell_delivery_area": "DELIVERY_AREA_DE_LU",
+//         "delivery_period": {
+//           "start_time": "2026-01-07T12:00:00Z",
+//           "duration": "DELIVERY_DURATION_60"
+//         },
+//         "execution_time": "2026-01-07T11:59:45Z",
+//         "price": { "currency": "EUR", "amount": "85.75" },
+//         "quantity": { "mw": "1.0" },
+//         "state": "TRADE_STATE_ACTIVE"
+//       }
+//     }
+//     ```
+//
 message ReceivePublicTradesStreamResponse {
   // The public trade that has been executed and is being broadcasted in
   // real-time.
   PublicTrade public_trade = 1;
 }
 
-// Subscribe to the stream of public order book updates.
+// Request message to subscribe to the stream of public order book updates.
 //
-// This stream provides historical replay and real-time updates of public
-// order book records.
+// This request optionally replays historical public order book updates and can
+// remain open to stream newly observed updates. Records are emitted only if
+// they match both the replay window (`start_time` / `end_time`) and the
+// attribute constraints in `filter`.
 //
 // !!! note "Replay Window Semantics"
 //     The replay window is defined over the order book update time
@@ -1250,34 +1272,30 @@ message ReceivePublicTradesStreamResponse {
 //
 //     `start_time` ≤ update_time < `end_time`
 //
-//     - If `start_time` is omitted, only new order book updates observed after
-//       the connection is established are streamed.
-//     - If `end_time` is set, it must refer to a timestamp in the past.
+//     - If `start_time` is omitted, only updates observed after the connection
+//       is established are emitted.
 //     - If `end_time` is omitted, the stream remains open and continues
 //       emitting new updates.
+//     - If `end_time` is set, it must refer to a timestamp in the past. If it
+//       lies in the past relative to the connection time, the server returns no
+//       entries and closes the stream immediately.
 //
 // !!! note "Filtering"
 //     The optional `filter` restricts which order book records are emitted
 //     (e.g., by delivery period, delivery area, or market side). Filtering is
 //     applied in addition to the replay window.
 //
-// !!! note "Stream Termination & Reconnect"
-//     The server may terminate long-lived streams for operational reasons.
-//     Clients should treat streams as best-effort and be prepared to reconnect.
-//
 message ReceivePublicOrderBookStreamRequest {
   // Optional filter to narrow down the public order book entries returned.
   PublicOrderBookFilter filter = 1;
 
-  // Optional; if set, retrieves order book updates executed at or after this
-  // timestamp. For example, setting this to "now - X hours" allows a client to
-  // receive historical updates covering the last X hours. If omitted, only new
-  // order book updates from the time of connection are streamed.
+  // Optional; start of the replay window for order book update time
+  // (inclusive). If omitted, only new updates observed after the connection
+  // is established are emitted.
   google.protobuf.Timestamp start_time = 2;
 
-  // Optional; if set, stops streaming order book updates after this timestamp.
-  // !!! note
-  //     end_time must be in the past.
+  // Optional; end of the replay window for order book update time
+  // (exclusive). If set, it must refer to a timestamp in the past.
   google.protobuf.Timestamp end_time = 3;
 }
 

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -662,8 +662,7 @@ message PublicOrderBookRecord {
 //
 // !!! note "Terminology"
 //     - DeliveryDuration: A fixed interval (e.g., 15, 30, or 60 minutes).
-//     - DeliveryPeriod: A combination of a start time and a
-//       DeliveryDuration.
+//     - DeliveryPeriod: A combination of a start time and a DeliveryDuration.
 //
 // !!! note "Matching Semantics"
 //     - Delivery periods are matched by their start time using a half-open

--- a/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
+++ b/proto/frequenz/api/electricity_trading/v1/electricity_trading.proto
@@ -607,6 +607,52 @@ message PublicTrade {
   TradeState state = 8;
 }
 
+// PublicOrderBookRecord represents a snapshot of an order book entry at
+// a specific point in time.
+//
+// Each record captures the state of an individual order when it is first
+// entered and subsequently updated.
+//
+// !!! note
+//     An order may generate multiple records over time, each corresponding to a
+// different update event on the order book.
+message PublicOrderBookRecord {
+  // The order book identifier.
+  uint64 id = 1;
+
+  // Frequenz Delivery area, using the common API type.
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 2;
+
+  // Frequenz Delivery period, using the common API type.
+  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 3;
+
+  // Optional: The type of order (e.g., LIMIT, STOP_LIMIT, ICEBERG).
+  //
+  // If not set, the order type is unknown (for example, if the source market
+  // does not expose the order type).
+  optional OrderType type = 4;
+
+  // Indicates if the order was on the Buy or Sell side.
+  MarketSide side = 5;
+
+  // Order price, using the common API definition for price.
+  frequenz.api.common.v1alpha8.market.Price price = 6;
+
+  // Open order quantity, using the common API definition for power.
+  frequenz.api.common.v1alpha8.market.Power quantity = 7;
+
+  // Execution option (e.g., AON).
+  optional OrderExecutionOption execution_option = 8;
+
+  // Timestamp when the order was created on the order book.
+  google.protobuf.Timestamp create_time = 9;
+
+  // Timestamp when this particular update event occurred.
+  // Each update to an order will have its own update_time reflecting
+  // the moment that specific change occurred.
+  google.protobuf.Timestamp update_time = 10;
+}
+
 // Filters delivery periods by start time and duration.
 //
 // A delivery period is defined by a start timestamp and a fixed delivery
@@ -762,6 +808,27 @@ message PublicTradeFilter {
 
   // Optional; If set, only trades in this sell delivery area are returned.
   frequenz.api.common.v1alpha8.grid.DeliveryArea sell_delivery_area = 4;
+}
+
+// Parameters for filtering order book stream results.
+//
+// !!! note
+//     Multiple filters can be used in combination to narrow down the returned
+//     order book entries. For example, you can apply both delivery period and
+//     delivery area filters simultaneously to list only the order book entries
+//     for a specific time period in a given delivery area.
+message PublicOrderBookFilter {
+  // Optional; if set, only order book entries for this delivery period are
+  // returned.
+  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 1;
+
+  // Optional; if set, only order book entries for this delivery area are
+  // returned.
+  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 2;
+
+  // Optional; if set, only order book entries for this delivery period are
+  // returned.
+  optional MarketSide side = 3;
 }
 
 // Represents a request to create a new order for a specific Gridpool.
@@ -944,19 +1011,68 @@ message ListGridpoolOrdersResponse {
   frequenz.api.common.v1alpha8.pagination.PaginationInfo pagination_info = 2;
 }
 
-// Subscribe to Gridpool order stream.
-// This method provides real-time updates on Gridpool orders, making it useful
-// for dynamic analytics and real-time decision-making.
+// Subscribe to the stream of Gridpool order updates.
+//
+// This RPC streams order updates for the given Gridpool and optionally filters
+// the streamed orders.
+//
+// !!! note "Filter Semantics"
+//     The `delivery_time_filter` matches orders by their `delivery_period
+//     .start_time` using a half-open time interval:
+//
+//     - Time range: `start_time` ≤ period_start < `end_time`
+//     - If `start_time` is omitted, the interval is unbounded at the start.
+//     - If `end_time` is omitted, the interval is unbounded at the end.
+//     - If `delivery_time_filter` is omitted, no delivery-time filtering is
+//        applied.
+//
+// !!! note "Stream Lifetime"
+//     The stream starts immediately.
+//     - If `end_time` is set and is in the future, the server may close the
+//       stream once no further orders can match the filter (typically
+//       shortly after `end_time`).
+//     - If `end_time` is set and is in the past, the server returns no
+//       entries and closes the stream immediately.
+//     - If `end_time` is omitted, the stream remains open and continues
+//       emitting matching order updates until the client closes it.
+//
+// !!! note "Stream Termination & Reconnect"
+//     The server may terminate long-lived streams for operational reasons.
+//     Clients should treat streams as best-effort and be prepared to reconnect,
+//     resuming from the last observed `execution_time` if needed.
+//
+// !!! example "Example: Stream all future orders (no end bound)"
+//     ```json
+//     {
+//       "gridpool_id": 1,
+//       "filter": {
+//         "delivery_time_filter": {
+//           "time_interval": { "start_time": "2026-01-07T00:00:00Z" }
+//         }
+//       }
+//     }
+//     ```
+//
+// !!! example "Example: Stream orders for a delivery window"
+//     ```json
+//     {
+//       "gridpool_id": 1,
+//       "filter": {
+//         "delivery_time_filter": {
+//           "time_interval": {
+//             "start_time": "2026-01-07T00:00:00Z",
+//             "end_time": "2026-01-07T03:00:00Z"
+//           }
+//         }
+//       }
+//     }
+//     ```
+//
 message ReceiveGridpoolOrdersStreamRequest {
   // The gridpool to retrieve the orders for.
   uint64 gridpool_id = 1;
 
-  // Optional public orders filter.
-  //
-  // !!! Important Note Regarding "DeliveryPeriod Filter"
-  //     Ensure that the specified DeliveryPeriod is set for a future timeframe.
-  //     If a past or present period is selected, the stream will automatically
-  //     close and return no entries.
+  // Optional Gridpool orders filter.
   GridpoolOrderFilter filter = 2;
 }
 
@@ -989,9 +1105,51 @@ message ListGridpoolTradesResponse {
   frequenz.api.common.v1alpha8.pagination.PaginationInfo pagination_info = 2;
 }
 
-// Subscribe to the stream of gridpool trades.
-// This method provides real-time updates on newly executed gridpool trades,
-// making it useful dynamic analytics and real-time decision-making.
+// Subscribe to the stream of Gridpool trades.
+//
+// This RPC streams newly observed trades for the given Gridpool and optionally
+// filters them.
+//
+// !!! note "Filter Semantics"
+//     The `delivery_time_filter` matches trades by their `delivery_period
+//     .start_time` using a half-open time interval:
+//
+//     - Time range: `start_time` ≤ period_start < `end_time`
+//     - If `start_time` is omitted, the interval is unbounded at the start.
+//     - If `end_time` is omitted, the interval is unbounded at the end.
+//     - If `delivery_time_filter` is omitted, no delivery-time filtering is
+//       applied.
+//
+// !!! note "Stream Lifetime"
+//     The stream starts immediately.
+//     - If `end_time` is set and is in the past, the server returns no entries
+//       and closes the stream immediately.
+//     - If `end_time` is omitted, the stream remains open and emits matching
+//       trades until the client closes it.
+//     - If `end_time` is set and is in the future, the server may close the
+//       stream once no further trades can match the filter (typically
+//       shortly after `end_time`).
+//
+// !!! note "Stream Termination & Reconnect"
+//     The server may terminate long-lived streams for operational reasons.
+//     Clients should treat streams as best-effort and be prepared to reconnect,
+//     resuming from the last observed `execution_time` if needed.
+//
+// !!! example "Example: Stream all trades for the next hour"
+//     ```json
+//     {
+//       "gridpool_id": 1,
+//       "filter": {
+//         "delivery_time_filter": {
+//           "time_interval": {
+//             "start_time": "2026-01-07T10:00:00Z",
+//             "end_time": "2026-01-07T11:00:00Z"
+//           }
+//         }
+//       }
+//     }
+//     ```
+//
 message ReceiveGridpoolTradesStreamRequest {
   // The Gridpool to retrieve the trades for.
   uint64 gridpool_id = 1;
@@ -1008,10 +1166,57 @@ message ReceiveGridpoolTradesStreamResponse {
   Trade trade = 1;
 }
 
-
 // Subscribe to the stream of public trades.
-// This method provides real-time updates on newly executed public trades,
-// making it useful dynamic analytics and real-time decision-making.
+//
+// This stream supports both historical replay and real-time updates.
+// Trades are included only if they match both:
+//
+//   1) the replay window defined by `start_time` / `end_time` (execution time),
+//   2) the `filter` constraints (trade attributes such as delivery period,
+//      area and/or state.
+//
+// !!! note "Time Domains"
+//     This request uses two different time concepts:
+//     - `start_time` / `end_time` filter by trade execution time
+//       (`PublicTrade.execution_time`).
+//     - `filter.delivery_period` filters by the delivery period of the traded
+//       contract (`PublicTrade.delivery_period`), i.e., which product was
+//       traded.
+//
+// !!! note "Replay Window Semantics"
+//     The replay window is a half-open interval on execution time:
+//     `start_time` ≤ execution_time < `end_time`.
+//     - If `start_time` is omitted, the stream emits only new trades observed
+//       after the connection is established.
+//     - If `end_time` is omitted, the stream remains open and continues
+//       emitting new trades.
+//     - If `end_time` is set and is in the past, the server returns no entries
+//       and closes the stream immediately.
+//
+// !!! note "Stream Termination & Reconnect"
+//     The server may terminate long-lived streams for operational reasons.
+//     Clients should treat streams as best-effort and be prepared to reconnect,
+//     resuming from the last observed `execution_time` if needed.
+//
+// !!! example "Example: Stream live trades for a delivery period"
+//     The following request streams all future public trades for the specified
+//     delivery period as they occur:
+//
+//     ```json
+//     {
+//       "filter": {
+//         "delivery_period": {
+//           "start_time": "2026-01-07T12:00:00Z",
+//           "duration": "DELIVERY_DURATION_60"
+//         }
+//       }
+//     }
+//     ```
+//
+//     Since `start_time` and `end_time` are omitted, the stream emits only new
+//     trades observed after the connection is established and remains open
+//     until closed by the server or the client.
+//
 message ReceivePublicTradesStreamRequest {
   // Optional filter to specify which trades should be included in the stream.
   PublicTradeFilter filter = 1;
@@ -1034,84 +1239,32 @@ message ReceivePublicTradesStreamResponse {
   PublicTrade public_trade = 1;
 }
 
-// PublicOrderBookRecord represents a snapshot of an order book entry at
-// a specific point in time.
+// Subscribe to the stream of public order book updates.
 //
-// Each record captures the state of an individual order when it is first
-// entered and subsequently updated.
+// This stream provides historical replay and real-time updates of public
+// order book records.
 //
-// !!! note
-//     An order may generate multiple records over time, each corresponding to a
-// different update event on the order book.
-message PublicOrderBookRecord {
-  // The order book identifier.
-  uint64 id = 1;
-
-  // Frequenz Delivery area, using the common API type.
-  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 2;
-
-  // Frequenz Delivery period, using the common API type.
-  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 3;
-
-  // Optional: The type of order (e.g., LIMIT, STOP_LIMIT, ICEBERG).
-  //
-  // If not set, the order type is unknown (for example, if the source market
-  // does not expose the order type).
-  optional OrderType type = 4;
-
-  // Indicates if the order was on the Buy or Sell side.
-  MarketSide side = 5;
-
-  // Order price, using the common API definition for price.
-  frequenz.api.common.v1alpha8.market.Price price = 6;
-
-  // Open order quantity, using the common API definition for power.
-  frequenz.api.common.v1alpha8.market.Power quantity = 7;
-
-  // Execution option (e.g., AON).
-  optional OrderExecutionOption execution_option = 8;
-
-  // Timestamp when the order was created on the order book.
-  google.protobuf.Timestamp create_time = 9;
-
-  // Timestamp when this particular update event occurred.
-  // Each update to an order will have its own update_time reflecting
-  // the moment that specific change occurred.
-  google.protobuf.Timestamp update_time = 10;
-}
-
-// Parameters for filtering order book stream results.
+// !!! note "Replay Window Semantics"
+//     The replay window is defined over the order book update time
+//     (`PublicOrderBookRecord.update_time`) using a half-open interval:
 //
-// !!! note
-//     Multiple filters can be used in combination to narrow down the returned
-//     order book entries. For example, you can apply both delivery period and
-//     delivery area filters simultaneously to list only the order book entries
-//     for a specific time period in a given delivery area.
-message PublicOrderBookFilter {
-  // Optional; if set, only order book entries for this delivery period are
-  // returned.
-  frequenz.api.common.v1alpha8.grid.DeliveryPeriod delivery_period = 1;
-
-  // Optional; if set, only order book entries for this delivery area are
-  // returned.
-  frequenz.api.common.v1alpha8.grid.DeliveryArea delivery_area = 2;
-
-  // Optional; if set, only order book entries for this delivery period are
-  // returned.
-  optional MarketSide side = 3;
-}
-
-// Request to subscribe to the public order book stream.
+//     `start_time` ≤ update_time < `end_time`
 //
-// This RPC provides real-time updates on public order book entries for use in
-// live trading and backtesting. When a client application initially connects,
-// it may specify a start_time to retrieve historical order book updates.
-// For example, setting start_time to "now - X hours" causes the server to
-// replay all stored order book updates from that time onward. If start_time is
-// omitted, only new order book updates from the moment of connection will be
-// streamed. If an end_time is provided, it must be set to a timestamp in the
-// past. This ensures that the historical data window is complete, and no future
-// (incomplete) data is expected.
+//     - If `start_time` is omitted, only new order book updates observed after
+//       the connection is established are streamed.
+//     - If `end_time` is set, it must refer to a timestamp in the past.
+//     - If `end_time` is omitted, the stream remains open and continues
+//       emitting new updates.
+//
+// !!! note "Filtering"
+//     The optional `filter` restricts which order book records are emitted
+//     (e.g., by delivery period, delivery area, or market side). Filtering is
+//     applied in addition to the replay window.
+//
+// !!! note "Stream Termination & Reconnect"
+//     The server may terminate long-lived streams for operational reasons.
+//     Clients should treat streams as best-effort and be prepared to reconnect.
+//
 message ReceivePublicOrderBookStreamRequest {
   // Optional filter to narrow down the public order book entries returned.
   PublicOrderBookFilter filter = 1;
@@ -1128,8 +1281,62 @@ message ReceivePublicOrderBookStreamRequest {
   google.protobuf.Timestamp end_time = 3;
 }
 
-// Response message for the public order book stream, returning multiple order
-// book records.
+// Response message for the public order book stream.
+//
+// Each response message contains one or more `PublicOrderBookRecord` entries.
+// Records represent order book events (new, changed, or re-published states)
+// observed by the service.
+//
+// !!! note "Record Semantics"
+//     - A record represents the state of a single visible order book entry at
+//       a specific point in time.
+//     - A single order book entry may appear multiple times over the stream as
+//       it is updated over time.
+//     - `create_time` is the timestamp when the order book entry first
+//       appeared.
+//     - `update_time` is the timestamp of this specific update event and is the
+//       time used for replay (`start_time` / `end_time`).
+//
+// !!! note "Batching"
+//     The service may batch multiple records into one response message for
+//     efficiency. Clients should not assume a fixed batch size and should
+//     process records independently.
+//
+// !!! example "Example: Response with multiple order book entries"
+//     ```json
+//     {
+//       "public_order_book_records": [
+//         {
+//           "id": "1001",
+//           "delivery_area": "DELIVERY_AREA_DE_LU",
+//           "delivery_period": {
+//             "start_time": "2026-01-07T12:00:00Z",
+//             "duration": "DELIVERY_DURATION_60"
+//           },
+//           "side": "MARKET_SIDE_BUY",
+//           "price": { "currency": "EUR", "amount": "85.50" },
+//           "quantity": { "mw": "2.0" },
+//           "create_time": "2026-01-07T11:58:10Z",
+//           "update_time": "2026-01-07T11:58:10Z"
+//         },
+//         {
+//           "id": "1002",
+//           "delivery_area": "DELIVERY_AREA_DE_LU",
+//           "delivery_period": {
+//             "start_time": "2026-01-07T12:00:00Z",
+//             "duration": "DELIVERY_DURATION_60"
+//           },
+//           "side": "MARKET_SIDE_SELL",
+//           "price": { "currency": "EUR", "amount": "86.00" },
+//           "quantity": { "mw": "1.5" },
+//           "create_time": "2026-01-07T11:58:20Z",
+//           "update_time": "2026-01-07T11:58:20Z"
+//         }
+//       ]
+//     }
+//     ```
+//
 message ReceivePublicOrderBookStreamResponse {
+  // List of order book records.
   repeated PublicOrderBookRecord public_order_book_records = 1;
 }


### PR DESCRIPTION
- Clarify replay vs attribute filtering semantics for public trades and order book streams
- Document half-open time interval behavior and stream lifetime rules
- Add concise reconnect / best-effort streaming notes
- Extend public order book stream response documentation with a simple example