### PR TITLE
fix(docs): disable strict mode in mkdocs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,6 @@
 
 ## Bug Fixes
 
+* Disable strict mode in mkdocs to prevent build failures due to Griffe warnings ([#206](https://github.com/frequenz-floss/frequenz-api-electricity-trading/issues/206)).
+
 <!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ copyright: "Copyright © 2023 Frequenz Energy-as-a-Service GmbH"
 repo_name: "frequenz-api-electricity-trading"
 repo_url: "https://github.com/frequenz-floss/frequenz-api-electricity-trading"
 edit_uri: "edit/v0.x.x/docs/"
-strict: true  # Treat warnings as errors
+strict: false # Allow warnings without failing the build
 
 # Build directories
 theme:


### PR DESCRIPTION
This prevents the documentation build from failing due to Griffe warnings about missing type annotations in generated gRPC code.

Fixes https://github.com/frequenz-floss/frequenz-api-electricity-trading/issues/206