### PR TITLE
Trigger repo-config-migration in the merge queue

### DIFF
--- a/.github/workflows/repo-config-migration.yaml
+++ b/.github/workflows/repo-config-migration.yaml
@@ -19,6 +19,7 @@
 name: Repo Config Migration
 
 on:
+  merge_group:  # To allow using this as a required check for merging
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
@@ -30,7 +31,10 @@ permissions:
 jobs:
   repo-config-migration:
     name: Migrate Repo Config
-    if: contains(github.event.pull_request.title, 'the repo-config group')
+    # Skip if it was triggered by the merge queue, we only need it to be present
+    if: |
+      github.event_name == 'pull_request_target' &&
+      contains(github.event.pull_request.title, 'the repo-config group')
     runs-on: ubuntu-24.04
     steps:
       - name: Generate token


### PR DESCRIPTION
To be able to check that repo-config-migration as a check to avoid accidental merges if the migration script failed, and we want to use a merge queue, we need to trigger the workflow in the merge queue and just skip the job, so nothing is really done but the job result is present and not failed.
